### PR TITLE
[AI-481] Rio-Tiler Clipped Tiles

### DIFF
--- a/docs/src/mosaic.md
+++ b/docs/src/mosaic.md
@@ -45,7 +45,7 @@ Inputs:
 - **chunk_size**: optional, control the number of assets to process per loop.
 - **threads**: optional, number of threads to use in each loop.
 - **allowed_exceptions**: optional, allow some exceptions to be ignored.
-- **\*kwargs**: tiler specific keyword arguments.
+- **\*\*kwargs**: tiler specific keyword arguments.
 
 Returns:
 - img, assets_used : tuple of ImageData and list of used assets to construct the output data.

--- a/docs/src/mosaic.md
+++ b/docs/src/mosaic.md
@@ -45,7 +45,7 @@ Inputs:
 - **chunk_size**: optional, control the number of assets to process per loop.
 - **threads**: optional, number of threads to use in each loop.
 - **allowed_exceptions**: optional, allow some exceptions to be ignored.
-- **\*\*kwargs**: tiler specific keyword arguments.
+- **\*kwargs**: tiler specific keyword arguments.
 
 Returns:
 - img, assets_used : tuple of ImageData and list of used assets to construct the output data.

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -299,6 +299,7 @@ class COGReader(BaseReader):
         tile_y: int,
         tile_z: int,
         tilesize: int = 256,
+        aoi: Optional[Dict] = None,
         indexes: Optional[Indexes] = None,
         expression: Optional[str] = None,
         tile_buffer: Optional[NumType] = None,
@@ -310,6 +311,7 @@ class COGReader(BaseReader):
             tile_x (int): Tile's horizontal index.
             tile_y (int): Tile's vertical index.
             tile_z (int): Tile's zoom level index.
+            aoi (dict, optional): GeoJson area of interest.
             tilesize (int, optional): Output image size. Defaults to `256`.
             indexes (int or sequence of int, optional): Band indexes.
             expression (str, optional): rio-tiler expression (e.g. b1/b2+b3).
@@ -345,6 +347,24 @@ class COGReader(BaseReader):
 
             # Buffered Tile Size
             tilesize += int(tile_buffer * 2)
+
+        if aoi is not None:
+            cutline = create_cutline(self.dataset, aoi, geometry_crs="epsg:4326")
+            vrt_options = kwargs.pop("vrt_options", {})
+            vrt_options.update({"cutline": cutline})
+
+            return self.part(
+                tile_bounds,
+                dst_crs=self.tms.rasterio_crs,
+                bounds_crs=None,
+                height=tilesize,
+                width=tilesize,
+                max_size=None,
+                indexes=indexes,
+                expression=expression,
+                vrt_options=vrt_options,
+                **kwargs,
+            )
 
         return self.part(
             tile_bounds,

--- a/rio_tiler/io/cogeo.py
+++ b/rio_tiler/io/cogeo.py
@@ -348,23 +348,10 @@ class COGReader(BaseReader):
             # Buffered Tile Size
             tilesize += int(tile_buffer * 2)
 
+        vrt_options = kwargs.pop("vrt_options", {})
         if aoi is not None:
             cutline = create_cutline(self.dataset, aoi, geometry_crs="epsg:4326")
-            vrt_options = kwargs.pop("vrt_options", {})
             vrt_options.update({"cutline": cutline})
-
-            return self.part(
-                tile_bounds,
-                dst_crs=self.tms.rasterio_crs,
-                bounds_crs=None,
-                height=tilesize,
-                width=tilesize,
-                max_size=None,
-                indexes=indexes,
-                expression=expression,
-                vrt_options=vrt_options,
-                **kwargs,
-            )
 
         return self.part(
             tile_bounds,
@@ -375,6 +362,7 @@ class COGReader(BaseReader):
             max_size=None,
             indexes=indexes,
             expression=expression,
+            vrt_options=vrt_options,
             **kwargs,
         )
 

--- a/tests/test_io_cogeo.py
+++ b/tests/test_io_cogeo.py
@@ -145,6 +145,45 @@ def test_info_valid():
         assert meta.nodata_type == "Nodata"
 
 
+def test_tile_aoi():
+    with COGReader(COG_NODATA) as cog:
+        feature = {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-56.4697265625, 74.17307693616263],
+                        [-57.667236328125, 73.53462847039683],
+                        [-57.59033203125, 73.13451013251789],
+                        [-56.195068359375, 72.94865294642922],
+                        [-54.964599609375, 72.96797135377102],
+                        [-53.887939453125, 73.84623016391944],
+                        [-53.97583007812499, 74.0165183926664],
+                        [-54.73388671875, 74.23289305339864],
+                        [-55.54687499999999, 74.2269213699517],
+                        [-56.129150390625, 74.21497138945001],
+                        [-56.2060546875, 74.21198251594369],
+                        [-56.4697265625, 74.17307693616263],
+                    ]
+                ],
+            },
+        }
+        # Successful None case.
+        img = cog.tile(43, 24, 7, aoi=None)
+        assert img.data.shape == (1, 256, 256)
+
+        img = cog.tile(43, 24, 7, aoi=feature)
+        assert img.data.shape == (1, 256, 256)
+        assert img.band_names == ["1"]
+
+        # Expression - This COG has 2 bands.
+        img = cog.tile(43, 24, 7, aoi=feature, expression="b1*2;b1-100")
+        assert img.data.shape == (2, 256, 256)
+        assert img.band_names == ["b1*2", "b1-100"]
+
+
 def test_tile_valid_default():
     """Should return a 3 bands array and a full valid mask."""
     with COGReader(COG_NODATA) as cog:


### PR DESCRIPTION
## What?

This PR adds the ability to clip tiles to a GeoJSON boundary with rio-tiler. Rio-tiler can take a GeoJSON feature or more specifically, just a `geometry as input. From the tests, riotiler will tile both a regular image and any type of band expression. 

![image](https://user-images.githubusercontent.com/10663198/169552224-4f051f45-1557-46c4-a4e9-2bb9df6aa5e2.png)