### PR TITLE
`7.8.1`: Re-introduce `aoi` argument to `Reader::tile()` to support clipped tiles

### DIFF
--- a/rio_tiler/io/rasterio.py
+++ b/rio_tiler/io/rasterio.py
@@ -38,6 +38,7 @@ from rio_tiler.types import BBox, Indexes, NumType, RIOResampling
 from rio_tiler.utils import (
     CRS_to_uri,
     _validate_shape_input,
+    create_cutline,
     has_alpha_band,
     has_mask_band,
 )
@@ -254,6 +255,7 @@ class Reader(BaseReader):
         tile_y: int,
         tile_z: int,
         tilesize: int = 256,
+        aoi: Optional[Dict] = None,
         indexes: Optional[Indexes] = None,
         expression: Optional[str] = None,
         buffer: Optional[float] = None,
@@ -280,6 +282,11 @@ class Reader(BaseReader):
                 f"Tile(x={tile_x}, y={tile_y}, z={tile_z}) is outside bounds"
             )
 
+        vrt_options = kwargs.pop("vrt_options", {})
+        if aoi is not None:
+            cutline = create_cutline(self.dataset, aoi, geometry_crs="epsg:4326")
+            vrt_options.update({"cutline": cutline})
+
         return self.part(
             tuple(self.tms.xy_bounds(Tile(x=tile_x, y=tile_y, z=tile_z))),
             dst_crs=self.tms.rasterio_crs,
@@ -290,6 +297,7 @@ class Reader(BaseReader):
             indexes=indexes,
             expression=expression,
             buffer=buffer,
+            vrt_options=vrt_options,
             **kwargs,
         )
 

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -151,6 +151,7 @@ def read(
                 "add_alpha": True,
                 "resampling": warp_resampling,
                 "dtype": src_dst.dtypes[0],
+                "init_dest_nodata": False,
             }
 
             if nodata is not None:

--- a/rio_tiler/reader.py
+++ b/rio_tiler/reader.py
@@ -151,10 +151,15 @@ def read(
                 "add_alpha": True,
                 "resampling": warp_resampling,
                 "dtype": src_dst.dtypes[0],
-                "init_dest_nodata": False,
             }
 
-            if nodata is not None:
+            if nodata is None:
+                vrt_params.update(
+                    {
+                        "init_dest_nodata": False
+                    }
+                )
+            else:
                 vrt_params.update(
                     {
                         "nodata": nodata,


### PR DESCRIPTION
**🚨 Reminder: this is a public repo 🚨**

This PR rebases the changes from https://github.com/SenteraLLC/rio-tiler/pull/2 onto the latest 7.8.1 release of rio-tiler. This work is being done in tandem with https://github.com/SenteraLLC/titiler/pull/6 to modernize the SenteraLLC fork of TiTiler.

More specifically, it:
- adds support for an `aoi` argument to the `Reader::tile()` method
- (to support new builds of GDAL) sets VRT param `"init_dest_nodata": False` to support COGs with a per-dataset mask